### PR TITLE
Dispose tray icon on shutdown

### DIFF
--- a/KeepAwake/MainForm.cs
+++ b/KeepAwake/MainForm.cs
@@ -67,6 +67,10 @@ namespace KeepAwake
 
         private void OnExit(object? sender, EventArgs e)
         {
+            // Dispose tray icon before exiting the application
+            trayIcon.Visible = false;
+            trayIcon.Dispose();
+
             Application.Exit();
         }
 
@@ -85,8 +89,13 @@ namespace KeepAwake
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
-            base.OnFormClosing(e);
+            // Save state and dispose of the tray icon before the form closes
             SaveWindowStates();
+
+            trayIcon.Visible = false;
+            trayIcon.Dispose();
+
+            base.OnFormClosing(e);
         }
 
         private void SaveWindowStates()


### PR DESCRIPTION
## Summary
- dispose the tray icon before exiting KeepAwake
- clean up tray icon on form closing

## Testing
- `dotnet build KeepAwake/KeepAwake.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404fdd2e7c8320b5276d328fb440ec